### PR TITLE
Fixed Wrist - Removed Kalman Filter

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -823,23 +823,6 @@ public class RobotContainer {
         stopIntakeOnPickup.onTrue(
             new InstantCommand(() -> m_IntakeSubsystem.stop())
         );
-// test this bit once the rest works
-        // stopIntakeOnPickup.onTrue(
-        //     new SequentialCommandGroup(
-        //         new InstantCommand(
-        //             () -> m_shoulderSubsystem.setTarget(0)
-        //         ),
-        //         new InstantCommand(
-        //             () -> m_elbowSubsystem.setTarget(0)
-        //         ), 
-        //         new InstantCommand(
-        //             () -> m_wristSubsystem.setTarget(-5.22)
-        //         ), 
-        //         new InstantCommand(
-        //             () -> m_IntakeSubsystem.stop()
-        //         )
-        //     )
-        // );
 
         /* Driver Buttons */
         m_swerve.setDefaultCommand(
@@ -851,7 +834,6 @@ public class RobotContainer {
                 () -> robotCentric.getAsBoolean()
             )
         );
-        
         
         zeroGyro.onTrue(new InstantCommand(() -> m_swerve.zeroGyro()));
         

--- a/src/main/java/frc/robot/commands/ArmToAngles.java
+++ b/src/main/java/frc/robot/commands/ArmToAngles.java
@@ -15,8 +15,6 @@ public class ArmToAngles extends CommandBase {
     private double elbowAngle;
     private double shoulderAngle;
 
-    private double angle;
-
     public ArmToAngles(WristSubsystem wrist, ElbowSubsystem elbow, ShoulderSubsystem shoulder, double shoulderAngle, double elbowAngle, double wristAngle) {
         this.m_wrist = wrist;
         this.m_elbow = elbow;

--- a/src/main/java/frc/robot/commands/ArmToPoint.java
+++ b/src/main/java/frc/robot/commands/ArmToPoint.java
@@ -5,7 +5,6 @@ import edu.wpi.first.math.numbers.N2;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.ElbowSubsystem;
 import frc.robot.subsystems.ShoulderSubsystem;
-import frc.robot.subsystems.WristSubsystem;
 import frc.robot.util.ArmPathPlanner;
 import frc.robot.util.Point;
 

--- a/src/main/java/frc/robot/commands/DriveToPoint.java
+++ b/src/main/java/frc/robot/commands/DriveToPoint.java
@@ -4,7 +4,6 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.subsystems.Swerve;
 

--- a/src/main/java/frc/robot/subsystems/ElbowSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElbowSubsystem.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
-import frc.robot.Constants;
 
 public class ElbowSubsystem extends ServoMotorSubsystem {
 

--- a/src/main/java/frc/robot/subsystems/ServoMotorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ServoMotorSubsystem.java
@@ -6,16 +6,12 @@ import com.revrobotics.RelativeEncoder;
 
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.PowerDistribution;
-import edu.wpi.first.wpilibj.PowerDistribution.ModuleType;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public abstract class ServoMotorSubsystem extends SubsystemBase {
     private CANSparkMax m_motor;
     private RelativeEncoder encoder;
-    private PowerDistribution pdp;
 
     private PIDController m_pidController;
 
@@ -34,7 +30,6 @@ public abstract class ServoMotorSubsystem extends SubsystemBase {
 
     private String subsystemName;
 
-    private boolean inverted;
     public static class ServoMotorSubsystemConfig {
         public double nominalVoltage = 12.6;
         public double rampTime = 0.125;

--- a/src/main/java/frc/robot/subsystems/ShoulderSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShoulderSubsystem.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
-import frc.robot.Constants;
 
 public class ShoulderSubsystem extends ServoMotorSubsystem {
 

--- a/src/main/java/frc/robot/subsystems/WristSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/WristSubsystem.java
@@ -1,14 +1,11 @@
 package frc.robot.subsystems;
 
 import edu.wpi.first.wpilibj.AnalogPotentiometer;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants;
-import frc.robot.util.KalmanFilter;
 
 public class WristSubsystem extends ServoMotorSubsystem {
 
     AnalogPotentiometer pot;
-    KalmanFilter kf = new KalmanFilter(0.1, 1.0);
 
     public WristSubsystem(ServoMotorSubsystemConfig config) {
         super(config);
@@ -33,19 +30,5 @@ public class WristSubsystem extends ServoMotorSubsystem {
 
     public void wristDown() {
         super.setTarget(getTargetAngle() - 2.0);
-    }
-
-    @Override
-    public double getCurrentAngle() {
-        return kf.lastMeasurement();
-    }
-
-    @Override
-    public void periodic() {
-        super.periodic();
-        double adjustedAngle = kf.filter(pot.get(), super.getCurrentAngle());
-        SmartDashboard.putNumber("wrist pot reading", pot.get());
-        SmartDashboard.putNumber("adjusted wrist reading", adjustedAngle);
-        SmartDashboard.putNumber("adjusted wrist reading last", kf.lastMeasurement());
     }
 }


### PR DESCRIPTION
Wrist would collapse onto itself. The problem was with a faulty Kalman Filter. Removed it so now the wrist functions as it used to.